### PR TITLE
tryInject for optional and inject for non optional

### DIFF
--- a/Example/TPInjector/AppDelegate.swift
+++ b/Example/TPInjector/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, Injectable {
 
   func applicationDidFinishLaunching(_ aNotification: Notification) {
     setupDefaultInjector()
-    AppDelegate.inject(LoginService.self)?.login()
+    AppDelegate.inject(LoginService.self).login()
   }
 
   func applicationWillTerminate(_ aNotification: Notification) {

--- a/Example/TPInjector/LoginService/LoginService.swift
+++ b/Example/TPInjector/LoginService/LoginService.swift
@@ -16,8 +16,8 @@ class LoginServiceImpl: LoginService, Injectable {
 
   private let networkService: NetworkService
 
-  init(networkService: NetworkService = inject()!,
-       userName: String = inject("user_name")!) {
+  init(networkService: NetworkService = inject(),
+       userName: String = inject("user_name")) {
     self.networkService = networkService
     print("UserName: \(userName)")
   }

--- a/Example/TPInjector/NetworkService/NetworkService.swift
+++ b/Example/TPInjector/NetworkService/NetworkService.swift
@@ -11,11 +11,12 @@ protocol NetworkService {
 }
 
 class NetworkServiceImpl: NetworkService, Injectable {
-  let api_key = inject("api_key", String.self)!
-  let api_url: NSURL = inject("api_url")!
+  let api_key = inject("api_key", String.self)
+  let api_url: NSURL = inject("api_url")
+  let api_args = tryInject("api_args", Array<String>.self) ?? []
 
   init() {
-    print("Network service at \(api_url) using key: \(api_key)")
+    print("Network service at \(api_url) using key: \(api_key) and args: \(api_args)")
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@
   DefaultInjector.register(service: LoginService.self, with: LoginServiceImpl())
 ```
 
-To inject dependecies you add `Injectable` protocol to your class/struct definition and `inject` static method to inject dependencies:
+To inject dependecies you add `Injectable` protocol to your class/struct definition and `inject` / `tryInject` static methods to inject dependencies:
 
 ```swift
 class ClassWithDependecies: Injectable {
 
-  private let networkService = inject(NetworkService.self)!
-  private let api_key = inject("api_key", String.self)!
-  private let api_url: NSURL = inject("api_url")!
+  private let networkService = inject(NetworkService.self)
+  private let api_key = inject("api_key", String.self)
+  private let api_url: NSURL = tryInject("api_url") ?? NSURL(string: "https://default.com")
 
-  init(loginService: LoginService = inject()!) {
+  init(loginService: LoginService = inject()) {
 
   }
 }

--- a/TPInjector.podspec
+++ b/TPInjector.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TPInjector'
-  s.version          = '0.1.0'
+  s.version          = '0.2.0'
   s.summary          = 'Swift dependency injection'
   s.description      = <<-DESC
 Simple swift dependency injection framework

--- a/TPInjector/Classes/Injectable.swift
+++ b/TPInjector/Classes/Injectable.swift
@@ -8,19 +8,35 @@ public protocol Injectable {}
 public extension Injectable {
   public static var injector: Injector { return DefaultInjector.injector }
 
-  public static func inject<T>(_ key: String) -> T? {
+  public static func tryInject<T>(_ key: String) -> T? {
     return injector.get(key)
   }
 
-  public static func inject<T>(_ key: String, _ type: T.Type) -> T? {
+  public static func tryInject<T>(_ key: String, _ type: T.Type) -> T? {
     return injector.get(key)
   }
 
-  public static func inject<T>(_ service: T.Type) -> T? {
+  public static func tryInject<T>(_ service: T.Type) -> T? {
     return injector.get()
   }
 
-  public static func inject<T>() -> T? {
+  public static func tryInject<T>() -> T? {
     return injector.get()
+  }
+
+  public static func inject<T>(_ key: String) -> T {
+    return injector.get(key)!
+  }
+
+  public static func inject<T>(_ key: String, _ type: T.Type) -> T {
+    return injector.get(key)!
+  }
+
+  public static func inject<T>(_ service: T.Type) -> T {
+    return injector.get()!
+  }
+
+  public static func inject<T>() -> T {
+    return injector.get()!
   }
 }


### PR DESCRIPTION
self-merge
   
  `tryInject` is used when we allow for the dependency to not exist
  `inject` when we must have the dependency or crash